### PR TITLE
Fix detection of the last key pressed

### DIFF
--- a/elscreen.el
+++ b/elscreen.el
@@ -988,7 +988,7 @@ is ommitted, current screen will survive."
 (defun elscreen-jump ()
   "Switch to specified screen."
   (interactive)
-  (let ((next-screen (string-to-number (string last-command-char))))
+  (let ((next-screen (string-to-number (string last-command-event))))
     (if (and (<= 0 next-screen) (<= next-screen 9))
         (elscreen-goto next-screen))))
 (defalias 'elscreen-jump-0 'elscreen-jump)


### PR DESCRIPTION
`last-command-char' is obsolete. (delete on r109145)

migrate to `last-command-event'.

FYI:

> Warning: `last-command-char' is an obsolete variable (as of Emacs at least 19.34); use`last-command-event' instead.
