### PR TITLE
Support environment without emacs-mac patch

### DIFF
--- a/elscreen.el
+++ b/elscreen.el
@@ -166,7 +166,7 @@ nil means don't display tabs."
   :group 'elscreen)
 
 (defface elscreen-tab-background-face
-  '((((type x w32 mac) (class color))
+  '((((type x w32 mac ns) (class color))
      :background "Gray50")
     (((class color))
      (:background "black")))
@@ -174,7 +174,7 @@ nil means don't display tabs."
   :group 'elscreen)
 
 (defface elscreen-tab-control-face
-  '((((type x w32 mac) (class color))
+  '((((type x w32 mac ns) (class color))
      (:background "white" :foreground "black" :underline "Gray50"))
     (((class color))
      (:background "white" :foreground "black" :underline t))
@@ -190,7 +190,7 @@ nil means don't display tabs."
   :group 'elscreen)
 
 (defface elscreen-tab-other-screen-face
-  '((((type x w32 mac) (class color))
+  '((((type x w32 mac ns) (class color))
      :background "Gray85" :foreground "Gray50")
     (((class color))
      (:background "blue" :foreground "black" :underline t)))


### PR DESCRIPTION
```lisp
;; Emacs-24.5 with emacs-mac patch
window-system
;; => mac

;; Emacs-24.5 and Emacs-25.1 without patch
window-system
;; => ns
```

Background (In Japanese)
https://twitter.com/masutaka/status/777359475627790336

I hope to merge this change. 😸 