### PR TITLE
Correct cond else clause

### DIFF
--- a/elscreen-buffer-list.el
+++ b/elscreen-buffer-list.el
@@ -85,7 +85,7 @@
   (interactive "P")
   (setq elscreen-buffer-list-enabled
         (cond ((null arg) (not elscreen-buffer-list-enabled))
-              (> arg 0)))
+              (t (> arg 0))))
   (message "Screen-specific buffer lists %s"
 	   (if elscreen-buffer-list-enabled "enabled" "disabled")))
 


### PR DESCRIPTION
Original code, '>' is treated as condition. This causes error because
'>' is not a variable, it is a function.