### PR TITLE
Make version string compatible with emacs 24 on melpa

### DIFF
--- a/elscreen.el
+++ b/elscreen.el
@@ -7,7 +7,7 @@
 ;; Revised:  April 11, 2012 by Emanuel Evans
 ;; Maintainer: Akinori MUSHA <knu@iDaemons.org>
 ;; Homepage: https://github.com/knu/elscreen
-;; Version:  2018-03-21
+;; Version:  20180321
 ;; Package-Requires: ((emacs "24"))
 ;; Keywords: window, convenience
 
@@ -46,7 +46,7 @@
 
 (declare-function iswitchb-read-buffer "iswitchb")
 
-(defconst elscreen-version "2018-03-21")
+(defconst elscreen-version "20180321")
 
 (defgroup elscreen nil
   "ElScreen -- Screen Manager for Emacs"


### PR DESCRIPTION
Melpa uses the built-in function 'version-to-list' to parse version
numbers of packages and add them to the 'archive-contents' file.  Up
to emacs 24, the version string "2018-03-21" would parse as:

 (2018 -3 3 -3 21)

Since emacs 25, the result of version-to-list is:

 (2018 -4 3 -4 21)

When these strings are read in from the melpa archive-contents file,
they are passed to 'package-version-join'.  Unfortunately, the version
of this function in emacs 24 doesn't understand the '-4' entries (only
added in emacs 25) and this prevents the package-list-packages screen
from being able to load.

When the separators are removed altogether, the version number parses
the same on all versions of emacs.  This also seems to fit the way
other packages using the date as the version format their version
number.