### PR TITLE
Fix byte compile error of elscreen-wl.el

### DIFF
--- a/elscreen-wl.el
+++ b/elscreen-wl.el
@@ -24,7 +24,6 @@
 
 (provide 'elscreen-wl)
 (require 'elscreen)
-(require 'wl)
 
 
 ;;; User Customizable Variables:


### PR DESCRIPTION
Hi @knu,

Fix the following byte compile error.

```
elscreen-wl.el:27:1:Error: Cannot open load file: No such file or directory, wl
```

I believe Elscreen should not require installation of Wanderlust.

Thanks.